### PR TITLE
feat(gateway): add structured error handling with proper HTTP status …

### DIFF
--- a/gateway/src/error.rs
+++ b/gateway/src/error.rs
@@ -1,0 +1,54 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde_json::json;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum GatewayError {
+    #[error("Redis error: {0}")]
+    Redis(#[from] redis::RedisError),
+
+    #[error("Redis error: {0}")]
+    DeadpoolRedis(#[from] deadpool_redis::redis::RedisError),
+
+    #[error("Pool error: {0}")]
+    Pool(#[from] deadpool_redis::PoolError),
+
+    #[error("Unauthorized")]
+    Unauthorized,
+
+    #[error("Instance not found: {0}")]
+    InstanceNotFound(String),
+
+    #[error("Invalid request: {0}")]
+    BadRequest(String),
+
+    #[error("Internal server error")]
+    Internal,
+}
+
+impl IntoResponse for GatewayError {
+    fn into_response(self) -> Response {
+        let (status, message) = match &self {
+            GatewayError::Redis(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("Redis operation error: {}", e)),
+            GatewayError::DeadpoolRedis(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("Deadpool Redis error: {}", e)),
+            GatewayError::Pool(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("Redis pool error: {}", e)),
+            GatewayError::Unauthorized => (StatusCode::UNAUTHORIZED, self.to_string()),
+            GatewayError::InstanceNotFound(id) => (StatusCode::NOT_FOUND, format!("Instance not found: {}", id)),
+            GatewayError::BadRequest(msg) => (StatusCode::BAD_REQUEST, format!("Bad request: {}", msg)),
+            GatewayError::Internal => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+        };
+
+        let body = Json(json!({
+            "error": message,
+            "status": status.as_u16()
+        }));
+
+        (status, body).into_response()
+    }
+}
+
+pub type Result<T> = std::result::Result<T, GatewayError>;

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod error;
+pub mod config;
+pub mod server;
+pub mod router;
+pub mod handlers;
+pub mod middleware;
+pub mod redis;

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -11,15 +11,21 @@ use tower_http::cors::CorsLayer;
 use tracing_subscriber::{fmt, prelude::*};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use tracing_subscriber::{filter::EnvFilter};
+
 mod config;
+mod handlers;
+mod error;
+mod redis;
+
 use crate::config::{Config, RedisConfig};
 
-mod handlers;
 use handlers::health::{health_check, metrics_endpoint};
 use handlers::keys::{get_key, set_key};
 
 mod middleware;
 use middleware::{logging::request_logger, metrics::metrics_middleware};
+
+
 
 /// Alias for Redis connection pool
 type RedisPool = Pool;


### PR DESCRIPTION
## This PR introduces structured error handling across the HTTP Gateway:

- **Custom Error Type (GatewayError)**

  Centralized error enum implemented with thiserror, covering Redis errors, invalid requests, authentication failures, and internal errors.

- **Consistent HTTP Status Codes**

  Each error variant maps to an appropriate status code (e.g., 404 Not Found for missing keys, 500 Internal Server Error for Redis connection issues, 401 Unauthorized for auth failures).

- **JSON Error Responses**

  All errors now return standardized JSON responses with error and status fields, making client-side handling predictable.

- **Refactored Handlers (keys.rs)**

  Removed unwrap() calls; handlers now return Result<T, GatewayError>, ensuring failures are propagated cleanly.

### Impact

- Eliminates server panics caused by unwrap().
- Improves reliability and user experience with structured API error messages.
- Establishes a foundation for uniform error handling across all future endpoints (hashes, raw commands, etc.).

### Related to: #8 – HTTP Gateway Core Server Implementation