### PR TITLE
feat(gateway): implement dynamic Redis instance routing with structur…

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -9,16 +9,19 @@ axum = "0.8.3"
 hyper = { version = "1.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
-redis = { version = "0.25", features = ["tokio-comp", "aio"] }
+redis = { version = "0.21.7", features = ["tokio-comp", "aio"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3" , features = ["env-filter"] }
 futures = "0.3"
 async-stream = "0.3"
+kube = { version = "0.87", features = ["runtime", "derive"] }
+k8s-openapi = { version = "0.20", features = ["v1_26"] }
 
 # New dependencies from the second Cargo.toml
 tower = "0.4"
 tower-http = { version = "0.5", features = ["cors", "trace"] }
 deadpool-redis = "0.10"
+deadpool = "0.10"
 uuid = { version = "1.4", features = ["v4"] }
 anyhow = "1.0"
 thiserror = "1.0"

--- a/gateway/config/default.toml
+++ b/gateway/config/default.toml
@@ -1,9 +1,16 @@
-[server]
-port = 8080
-
 [redis]
 url = "redis://127.0.0.1:6379/"
-pool_size = 16
+pool_size = 16  # (có thể không cần, nếu không dùng nữa)
+pool_max_size = 16
+pool_timeout_seconds = 5
+default_password = ""  # Hoặc bỏ dòng này nếu không dùng auth
 
 [logging]
 level = "info"
+
+[server]
+port = 8080
+
+[redis.health]
+refresh_interval_seconds = 30
+health_check_interval_seconds = 60

--- a/gateway/src/config.rs
+++ b/gateway/src/config.rs
@@ -12,6 +12,9 @@ pub struct ServerConfig {
 pub struct RedisConfig {
     pub url: String,
     pub pool_size: usize,
+    pub pool_max_size: usize,
+    pub pool_timeout_seconds: u64,
+    pub default_password: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/gateway/src/error.rs
+++ b/gateway/src/error.rs
@@ -5,14 +5,13 @@ use axum::{
 };
 use serde_json::json;
 use thiserror::Error;
+use deadpool_redis::CreatePoolError;
+use serde_json::Error as SerdeJsonError;
 
 #[derive(Error, Debug)]
 pub enum GatewayError {
     #[error("Redis error: {0}")]
     Redis(#[from] redis::RedisError),
-
-    #[error("Redis error: {0}")]
-    DeadpoolRedis(#[from] deadpool_redis::redis::RedisError),
 
     #[error("Pool error: {0}")]
     Pool(#[from] deadpool_redis::PoolError),
@@ -28,18 +27,29 @@ pub enum GatewayError {
 
     #[error("Internal server error")]
     Internal,
+
+    #[error("Kubernetes client error: {0}")]
+    KubeError(#[from] kube::Error),
+
+    #[error("Create pool error: {0}")]
+    CreatePool(#[from] CreatePoolError),
+
+    #[error("Serde JSON error: {0}")]
+    SerdeJson(#[from] SerdeJsonError),
 }
 
 impl IntoResponse for GatewayError {
     fn into_response(self) -> Response {
-        let (status, message) = match &self {
+        let (status, message) = match & self {
             GatewayError::Redis(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("Redis operation error: {}", e)),
-            GatewayError::DeadpoolRedis(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("Deadpool Redis error: {}", e)),
             GatewayError::Pool(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("Redis pool error: {}", e)),
             GatewayError::Unauthorized => (StatusCode::UNAUTHORIZED, self.to_string()),
             GatewayError::InstanceNotFound(id) => (StatusCode::NOT_FOUND, format!("Instance not found: {}", id)),
             GatewayError::BadRequest(msg) => (StatusCode::BAD_REQUEST, format!("Bad request: {}", msg)),
             GatewayError::Internal => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+            GatewayError::KubeError(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("Kubernetes client error: {}", e),),
+            GatewayError::CreatePool(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("Create pool error: {}", e)),
+            GatewayError::SerdeJson(e) => (StatusCode::BAD_REQUEST, format!("JSON error: {}", e)),
         };
 
         let body = Json(json!({

--- a/gateway/src/handlers/keys.rs
+++ b/gateway/src/handlers/keys.rs
@@ -1,40 +1,205 @@
 use axum::{
-    extract::{Path, State},
-    response::IntoResponse,
+    extract::{Query, Path, State},
+    response::{IntoResponse},
     Json,
 };
+
 use deadpool_redis::{
     redis::{AsyncCommands, FromRedisValue},
     Pool,
 };
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use serde_json::json;
 
-use crate::error::{GatewayError, Result}; // Import Result và GatewayError
+use crate::{
+    error::{GatewayError, Result},
+    server::AppState,
+};
 
-/// Alias cho pool
-type RedisPool = Pool;
 
-/// POST /set/:key/:value
-pub async fn set_key(
-    State(pool): State<RedisPool>,
-    Path((key, value)): Path<(String, String)>,
-) -> Result<impl IntoResponse> { // Trả về Result
-    let mut conn = pool.get().await?; // Xử lý lỗi từ pool.get()
-    let _: () = conn.set(&key, &value).await?; // Xử lý lỗi từ conn.set()
-
-    Ok(Json(json!({ "result": "OK" }))) // Trả về Ok nếu thành công
+#[derive(Deserialize)]
+pub struct SetKeyRequest {
+    value: String,
+    ttl_seconds: Option<u64>,
 }
 
-/// GET /get/:key
-pub async fn get_key(
-    State(pool): State<RedisPool>,
-    Path(key): Path<String>,
-) -> Result<impl IntoResponse> { // Trả về Result
-    let mut conn = pool.get().await?; // Xử lý lỗi từ pool.get()
-    let result: Option<String> = conn.get(&key).await?; // Xử lý lỗi từ conn.get()
+#[derive(Deserialize)]
+pub struct MethodOverride {
+    method: Option<String>,
+    value: Option<String>,
+    ttl_seconds: Option<u64>,
+}
 
-    match result {
-        Some(value) => Ok(Json(json!({ "result": value }))), // Trả về Ok nếu tìm thấy
-        None => Err(GatewayError::InstanceNotFound(format!("Key '{}' not found", key))), // Trả về lỗi nếu không tìm thấy
+#[derive(Serialize)]
+pub struct SetKeyResponse {
+    status: String,
+}
+
+#[derive(Serialize)]
+pub struct GetKeyResponse {
+    key: String,
+    value: String,
+}
+
+#[derive(Serialize)]
+pub struct DeleteKeyResponse {
+    deleted: u32,
+}
+
+//
+// /// Alias cho pool
+// type RedisPool = Pool;
+//
+// /// POST /set/:key/:value
+// pub async fn set_key(
+//     State(pool): State<RedisPool>,
+//     Path((key, value)): Path<(String, String)>,
+// ) -> Result<impl IntoResponse> { // Trả về Result
+//     let mut conn = pool.get().await?; // Xử lý lỗi từ pool.get()
+//     let _: () = conn.set(&key, &value).await?; // Xử lý lỗi từ conn.set()
+//
+//     Ok(Json(json!({ "result": "OK" }))) // Trả về Ok nếu thành công
+// }
+//
+// /// GET /get/:key
+// pub async fn get_key(
+//     State(pool): State<RedisPool>,
+//     Path(key): Path<String>,
+// ) -> Result<impl IntoResponse> { // Trả về Result
+//     let mut conn = pool.get().await?; // Xử lý lỗi từ pool.get()
+//     let result: Option<String> = conn.get(&key).await?; // Xử lý lỗi từ conn.get()
+//
+//     match result {
+//         Some(value) => Ok(Json(json!({ "result": value }))), // Trả về Ok nếu tìm thấy
+//         None => Err(GatewayError::InstanceNotFound(format!("Key '{}' not found", key))), // Trả về lỗi nếu không tìm thấy
+//     }
+// }
+
+
+pub async fn get_key(
+    Path((instance_name, key)): Path<(String, String)>,
+    Query(params): Query<MethodOverride>,
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>> {
+    // Handle method override
+    if let Some(method) = &params.method {
+        match method.to_uppercase().as_str() {
+            "POST" => return set_key_override(instance_name, key, params, state).await,
+            "DELETE" => return delete_key_method(instance_name, key, state).await,
+            _ => {}
+        }
     }
+
+    // Get Redis client for instance
+    let mut client = state
+        .redis_pool
+        .get_client(&instance_name)
+        .await
+        .ok_or_else(|| GatewayError::InstanceNotFound(instance_name.clone()))?;
+
+    // Execute Redis GET command
+    let value: Option<String> = redis::cmd("GET")
+        .arg(&key)
+        .query_async(&mut client)
+        .await
+        .map_err(GatewayError::Redis)?;
+
+    match value {
+        Some(v) => Ok(Json(serde_json::json!({
+            "key": key,
+            "value": v
+        }))),
+        None => Err(GatewayError::BadRequest(format!("Key '{}' not found", key))),
+    }
+}
+
+pub async fn set_key(
+    Path((instance_name, key)): Path<(String, String)>,
+    State(state): State<AppState>,
+    Json(payload): Json<SetKeyRequest>,
+) -> Result<Json<SetKeyResponse>> {
+    // Get Redis client for instance
+    let mut client = state
+        .redis_pool
+        .get_client(&instance_name)
+        .await
+        .ok_or_else(|| GatewayError::InstanceNotFound(instance_name))?;
+
+    // Execute Redis SET command with optional TTL
+    if let Some(ttl) = payload.ttl_seconds {
+        redis::cmd("SETEX")
+            .arg(&key)
+            .arg(ttl)
+            .arg(&payload.value)
+            .query_async::<_, ()>(&mut client)
+            .await
+            .map_err(GatewayError::Redis)?;
+    } else {
+        redis::cmd("SET")
+            .arg(&key)
+            .arg(&payload.value)
+            .query_async(&mut client)
+            .await
+            .map_err(GatewayError::Redis)?;
+    }
+
+    Ok(Json(SetKeyResponse {
+        status: "OK".to_string(),
+    }))
+}
+
+async fn set_key_override(
+    instance_name: String,
+    key: String,
+    params: MethodOverride,
+    state: AppState,
+) -> Result<Json<serde_json::Value>> {
+    let value = params.value.ok_or_else(|| {
+        GatewayError::BadRequest("Missing 'value' parameter for SET operation".to_string())
+    })?;
+
+    let request = SetKeyRequest {
+        value,
+        ttl_seconds: params.ttl_seconds,
+    };
+
+    let response = set_key(
+        Path((instance_name, key)),
+        State(state),
+        Json(request),
+    ).await?;
+
+    Ok(Json(serde_json::to_value(response.0)?))
+}
+
+pub async fn delete_key(
+    Path((instance_name, key)): Path<(String, String)>,
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>> {
+    delete_key_method(instance_name, key, state).await
+}
+
+async fn delete_key_method(
+    instance_name: String,
+    key: String,
+    state: AppState,
+) -> Result<Json<serde_json::Value>> {
+    // Get Redis client for instance
+    let mut client = state
+        .redis_pool
+        .get_client(&instance_name)
+        .await
+        .ok_or_else(|| GatewayError::InstanceNotFound(instance_name))?;
+
+    // Execute Redis DEL command
+    let deleted: u32 = redis::cmd("DEL")
+        .arg(&key)
+        .query_async(&mut client)
+        .await
+        .map_err(GatewayError::Redis)?;
+
+    Ok(Json(serde_json::json!({
+        "deleted": deleted
+    })))
 }

--- a/gateway/src/redis/mod.rs
+++ b/gateway/src/redis/mod.rs
@@ -1,0 +1,2 @@
+pub mod pool;
+pub mod client;

--- a/gateway/src/redis/pool.rs
+++ b/gateway/src/redis/pool.rs
@@ -1,0 +1,229 @@
+// src/redis/pool.rs
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::Duration,
+};
+use tokio::sync::RwLock;
+use redis::{Client, Connection};
+use deadpool_redis::{Config as PoolConfig, Pool, Runtime};
+
+use crate::{config::RedisConfig, error::Result};
+
+pub struct RedisPoolManager {
+    // các pool Redis được phân chia theo tên của các instance Redis.
+    pools: Arc<RwLock<HashMap<String, Pool>>>,
+    // Cấu hình Redis
+    config: RedisConfig,
+    // Đây là client Kubernetes
+    k8s_client: kube::Client,
+}
+
+impl RedisPoolManager {
+    // Tạo một đối tượng RedisPoolManager mới, khởi tạo client k8s, pools, config
+    pub async fn new(config: &RedisConfig) -> Result<Self> {
+        let k8s_client = kube::Client::try_default().await?;
+
+        Ok(Self {
+            pools: Arc::new(RwLock::new(HashMap::new())),
+            config: config.clone(),
+            k8s_client,
+        })
+    }
+
+    // lấy kết nối Redis từ pool đã có, nếu ko có pool hoặc ko lấy đc pool thì tạo pool mới.
+    pub async fn get_client(&self, instance_name: &str) -> Option<deadpool_redis::Connection> {
+        // Try to get existing pool
+        if let Some(pool) = self.get_pool(instance_name).await {
+            match pool.get().await {
+                Ok(conn) => return Some(conn),
+                Err(e) => {
+                    tracing::warn!("Failed to get connection from pool for {}: {}", instance_name, e);
+                    // Pool might be stale, remove it and try to recreate
+                    self.remove_pool(instance_name).await;
+                }
+            }
+        }
+
+        // Try to create new pool for this instance
+        if let Ok(pool) = self.create_pool_for_instance(instance_name).await {
+            self.add_pool(instance_name.to_string(), pool.clone()).await;
+            pool.get().await.ok()
+        } else {
+            None
+        }
+    }
+
+    // Lấy pool Redis của một instance cụ thể từ pools
+    async fn get_pool(&self, instance_name: &str) -> Option<Pool> {
+        let pools = self.pools.read().await;
+        pools.get(instance_name).cloned()
+    }
+
+
+    // Thêm một pool Redis vào pools khi đã tạo được pool mới.
+    async fn add_pool(&self, instance_name: String, pool: Pool) {
+        let mut pools = self.pools.write().await;
+        pools.insert(instance_name, pool);
+    }
+
+    // xoá pool Redis
+    async fn remove_pool(&self, instance_name: &str) {
+        let mut pools = self.pools.write().await;
+        pools.remove(instance_name);
+    }
+
+    // tạo ra một pool kết nối Redis mới cho một Redis instance
+    async fn create_pool_for_instance(&self, instance_name: &str) -> Result<Pool> {
+        // Discover Redis service in Kubernetes
+        let redis_url = self.discover_redis_service(instance_name).await?;
+
+        tracing::info!("Creating Redis pool for instance {} at {}", instance_name, redis_url);
+
+        // Create manager from Redis URL
+        let manager = deadpool_redis::Manager::new(redis_url.as_str())?;
+
+
+        let mut config = deadpool_redis::Config::from_url(&redis_url);
+
+        // Tạo PoolConfig nếu chưa có
+        let mut pool_cfg = config.get_pool_config();
+        pool_cfg.max_size = self.config.pool_max_size;
+        pool_cfg.timeouts.wait = Some(Duration::from_secs(self.config.pool_timeout_seconds));
+        config.pool = Some(pool_cfg);
+
+        // Tạo pool
+        let pool = config.create_pool(Some(Runtime::Tokio1))?;
+
+        // Test the connection
+        let mut conn = pool.get().await?;
+        redis::cmd("PING")
+            .query_async::<_, String>(conn.as_mut()) // <- sửa ở đây
+            .await?;
+
+        Ok(pool as deadpool_redis::Pool)
+
+    }
+
+
+    // khám phá dịch vụ Redis trong Kubernetes dựa trên tên instance
+    async fn discover_redis_service(&self, instance_name: &str) -> Result<String> {
+        use kube::{Api, api::ListParams};
+        use k8s_openapi::api::core::v1::Service;
+
+        let services: Api<Service> = Api::default_namespaced(self.k8s_client.clone());
+        let lp = ListParams::default().labels(&format!("instance={}", instance_name));
+
+        let service_list = services.list(&lp).await?;
+
+        if let Some(service) = service_list.items.first() {
+            if let (Some(name), Some(namespace)) = (&service.metadata.name, &service.metadata.namespace) {
+                // Construct internal Kubernetes DNS name
+                let host = format!("{}.{}.svc.cluster.local", name, namespace);
+                let port = service.spec
+                    .as_ref()
+                    .and_then(|spec| spec.ports.as_ref())
+                    .and_then(|ports| ports.first())
+                    .map(|port| port.port)
+                    .unwrap_or(6379);
+
+                let mut url = format!("redis://{}:{}", host, port);
+
+                // Add authentication if configured
+                if let Some(password) = &self.config.default_password {
+                    url = format!("redis://:{}@{}:{}", password, host, port);
+                }
+
+                return Ok(url);
+            }
+        }
+
+        Err(crate::error::GatewayError::InstanceNotFound(instance_name.to_string()))
+    }
+
+    pub async fn refresh_pools(&self) -> Result<()> {
+        // Discover all Redis instances
+        let instances = self.discover_all_instances().await?;
+
+        // Get current pools
+        let current_pools: Vec<String> = {
+            let pools = self.pools.read().await;
+            pools.keys().cloned().collect()
+        };
+
+        // Remove pools for instances that no longer exist
+        for pool_name in &current_pools {
+            if !instances.contains(pool_name) {
+                tracing::info!("Removing pool for deleted instance: {}", pool_name);
+                self.remove_pool(pool_name).await;
+            }
+        }
+
+        // Create pools for new instances
+        for instance in &instances {
+            if !current_pools.contains(instance) {
+                tracing::info!("Creating pool for new instance: {}", instance);
+                if let Ok(pool) = self.create_pool_for_instance(instance).await {
+                    self.add_pool(instance.clone(), pool).await;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    // khám phá tất cả các instance Redis đang chạy trong Kubernetes
+    async fn discover_all_instances(&self) -> Result<Vec<String>> {
+        use kube::{Api, api::ListParams};
+        use k8s_openapi::api::core::v1::Service;
+
+        let services: Api<Service> = Api::default_namespaced(self.k8s_client.clone());
+        let lp = ListParams::default().labels("app=redis");
+
+        let service_list = services.list(&lp).await?;
+
+        let instances: Vec<String> = service_list
+            .items
+            .iter()
+            .filter_map(|service| {
+                service.metadata.labels.as_ref()
+                    .and_then(|labels| labels.get("instance"))
+                    .cloned()
+            })
+            .collect();
+
+        Ok(instances)
+    }
+
+    // kiểm tra tình trạng (health) của tất cả các pool hiện có
+    pub async fn health_check(&self) -> HashMap<String, bool> {
+        let pools = self.pools.read().await;
+        let mut results = HashMap::new();
+
+        for (instance_name, pool) in pools.iter() {
+            match pool.get().await {
+                Ok(mut conn) => {
+                    match redis::cmd("PING").query_async::<_, String>(&mut conn).await {
+                        Ok(_) => results.insert(instance_name.clone(), true),
+                        Err(_) => results.insert(instance_name.clone(), false),
+                    };
+                }
+                Err(_) => {
+                    results.insert(instance_name.clone(), false);
+                }
+            }
+        }
+
+        results
+    }
+}
+
+impl Clone for RedisPoolManager {
+    fn clone(&self) -> Self {
+        Self {
+            pools: Arc::clone(&self.pools),
+            config: self.config.clone(),
+            k8s_client: self.k8s_client.clone(),
+        }
+    }
+}

--- a/gateway/src/server.rs
+++ b/gateway/src/server.rs
@@ -1,0 +1,8 @@
+// src/server.rs
+use crate::{config::Config, redis::pool::RedisPoolManager};
+
+#[derive(Clone)]
+pub struct AppState {
+    pub redis_pool: RedisPoolManager,
+    pub config: Config,
+}


### PR DESCRIPTION
### Summary

This PR extends the HTTP Gateway with multi-instance Redis support and structured key management APIs.
Clients can now target specific Redis instances dynamically discovered via Kubernetes services.

### Key Features

**Instance-aware API routes**
  - Endpoints now scoped under /instances/:instance_name/....
  - Example: GET /instances/my-redis/keys/mykey.
 
**Enhanced Key Management**
  - GET /keys/:key → fetch key value with error handling.
  - POST /keys/:key → set key with optional TTL.
  - DELETE /keys/:key → delete key and return number of removed entries.
  - Supports method override via query params (?method=POST&value=...) for compatibility.
 
**Kubernetes Redis Discovery**
  - RedisPoolManager dynamically discovers Redis services via Kubernetes API.
  - Pools automatically created/removed as services appear/disappear.
  - DNS resolution follows <svc>.<ns>.svc.cluster.local.
  - Authentication supported via default password in config.
 
**Connection Pool Refresh & Health Checks**
  - Background refresh discovers all Redis instances with label app=redis.
  - health_check() validates connection with PING.
 
**Error Handling Integration**
  - Unified GatewayError across all handlers.
  - Removes all unwrap() calls in favor of structured errors.

### Impact

- Enables multi-tenant Redis usage in Kubernetes environments.
- Improves fault tolerance by auto-removing stale pools and retrying discovery.
- Provides clean API responses with standardized JSON errors and success payloads.
- Sets foundation for hashes and raw command support on a per-instance basis.

### Related to
 #9: Redis Command Translation and Execution